### PR TITLE
Changed Drive Slip Current

### DIFF
--- a/src/main/java/frc/robot/constants/TunerConstants.java
+++ b/src/main/java/frc/robot/constants/TunerConstants.java
@@ -55,7 +55,7 @@ public class TunerConstants {
 
     // The stator current at which the wheels start to slip;
     // This needs to be tuned to your individual robot
-    private static final Current kSlipCurrent = Amps.of(120.0);
+    private static final Current kSlipCurrent = Amps.of(60.0);
 
     // Initial configs for the drive and steer motors and the CANcoder; these cannot be null.
     // Some configs will be overwritten; check the `with*InitialConfigs()` API documentation.


### PR DESCRIPTION
Change drive slip current from 120 -> 60 amps (for on-season bot)

Resolves #40 